### PR TITLE
Merge devel for pre-release 3

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
 		{
 			"label": "esbuild",
 			"type": "shell",
-			"command": "npx esbuild --bundle flowerful.ts --format=esm --outdir=build/ --platform=node",
+			"command": "npx esbuild --bundle gameSupport/games.coaw.ts --format=esm --outdir=build/ --platform=node",
 			"windows": {
 				"command": ""
 			},

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
 		{
 			"label": "esbuild",
 			"type": "shell",
-			"command": "npx esbuild --bundle gameSupport/games.coaw.ts --format=esm --outdir=build/ --platform=node",
+			"command": "npx esbuild --bundle gameSupport/games.coaw.ts --format=esm --outfile=./build/flowerful.js --platform=node",
 			"windows": {
 				"command": ""
 			},

--- a/flowerful.patches.ts
+++ b/flowerful.patches.ts
@@ -61,9 +61,11 @@ function Apply(patch: FlowerPatch)
             }
         }
 
+        let origRet;
+
         try
         {
-            orig.call(patch.obj, ...args);
+            origRet = orig.call(patch.obj, ...args);
         }
         catch (e)
         {
@@ -71,8 +73,14 @@ function Apply(patch: FlowerPatch)
             return;
         }
 
+        /**
+         * Todo: allow postfixes to modify the return data here
+         */
+
         WriteDebug(`Postfixes ${patch.postfixes.length}`);
         patch.postfixes.forEach(postfix => postfix.call(patch.obj, ...args));
+
+        return origRet;
     }
 
     patch.obj[patch.methodName] = wrapper.bind(patch.obj);

--- a/flowerful.patches.ts
+++ b/flowerful.patches.ts
@@ -78,7 +78,19 @@ function Apply(patch: FlowerPatch)
          */
 
         WriteDebug(`Postfixes ${patch.postfixes.length}`);
-        patch.postfixes.forEach(postfix => postfix.call(patch.obj, ...args));
+
+        for (const postfix of patch.postfixes)
+        {
+            try
+            {
+                postfix.call(patch.obj, ...args)
+            }
+            catch (e: any)
+            {
+                WriteLog("Flower", `Failed to run postfix: ${e.message}`);
+            }
+        }
+
 
         return origRet;
     }

--- a/flowerful.patches.ts
+++ b/flowerful.patches.ts
@@ -1,142 +1,153 @@
+import { LogSource } from "@flowerloader/api";
 import { FlowerPatch, Patchable, PatchFn } from "@flowerloader/api/FlowerPatch";
-import { WriteLog, WriteDebug } from "./flowerful";
 
-const patches: FlowerPatch[] = [];
-
-//Apply patches
-export function ApplyAllPatches()
+export class flowerPatcher
 {
-    for (const patch of patches)
-    {
-        Apply(patch)
-    }
-}
+    Patches: FlowerPatch[] = [];
+    MyLogSource: LogSource;
 
-function FindPatch(obj: Patchable, method: string)
-{
-    if (!obj[method])
-    {
-        console.error(`Method ${method} not found on ${obj}`);
-        return;
-    }
 
-    for (const patch of patches)
+    //Apply patches
+    ApplyAllPatches()
     {
-        if (patch.obj === obj && patch.methodName === method)
+        for (const patch of this.Patches)
         {
-            return patch;
+            this.Apply(patch)
         }
     }
 
-    const patch: FlowerPatch = {
-        obj: obj,
-        methodName: method,
-        prefixes: [],
-        postfixes: [],
-        applied: false,
-    }
-
-    patches.push(patch);
-    return patch;
-}
-
-/**
- * Binds a patch to an object. All patches are accumulated even after initial binding.
- * @param patch 
- * @returns false if this patch has already been bound
- */
-function Apply(patch: FlowerPatch): boolean
-{
-
-    /** Only apply patches once ever */
-    if (patch.applied)
-        return false;
-
-    /* eslint-disable-next-line @typescript-eslint/ban-types */
-    const orig = patch.obj[patch.methodName] as Function;
-
-    const wrapper: PatchFn = function (...args)
+    FindPatch(obj: Patchable, method: string)
     {
-        WriteDebug(`Running detour for ${patch.methodName}`);
-        // <-- this = obj
-
-        patch = FindPatch(patch.obj, patch.methodName)!;
-
-        WriteDebug(`Prefixes ${patch.prefixes.length}`);
-        //patch.prefixes.forEach(prefix => prefix.call(patch.obj, ...args));
-        //Allow ending the detour early
-        for (const prefix of patch.prefixes)
+        if (!obj[method])
         {
-            if (false === prefix.call(patch.obj, ...args))
-            {
-                WriteDebug("Ending detour");
-                return;
-            }
-        }
-
-        let origRet;
-
-        try
-        {
-            origRet = orig.call(patch.obj, ...args);
-        }
-        catch (e)
-        {
-            WriteLog("Flower", `Error running orig: ${e}`)
+            console.error(`Method ${method} not found on ${obj}`);
             return;
         }
 
-        /**
-         * Todo: allow postfixes to modify the return data here
-         */
-
-        WriteDebug(`Postfixes ${patch.postfixes.length}`);
-
-        for (const postfix of patch.postfixes)
+        for (const patch of this.Patches)
         {
-            try
+            if (patch.obj === obj && patch.methodName === method)
             {
-                postfix.call(patch.obj, ...args)
-            }
-            catch (e: any)
-            {
-                WriteLog("Flower", `Failed to run postfix: ${e.message}`);
+                return patch;
             }
         }
 
+        const patch: FlowerPatch = {
+            obj: obj,
+            methodName: method,
+            prefixes: [],
+            postfixes: [],
+            applied: false,
+        }
 
-        return origRet;
+        this.Patches.push(patch);
+        return patch;
     }
 
-    patch.obj[patch.methodName] = wrapper.bind(patch.obj);
-    return true;
-}
-
-/**
- * Registers a new patch with flower
- * @param obj any object that contains a method
- * @param methodName the string name of the method to patch
- * @param patch a function that runs when the method is called
- * @param isPrefix if this should run before the method (afterward otherwise)
- * @returns true on success
- */
-export function RegisterPatch(obj: Patchable, methodName: string, patch: PatchFn, isPrefix: boolean)
-{
-
-    WriteDebug(`Running RegisterPatch for ${methodName}`);
-
-    const accum = FindPatch(obj, methodName);
-    if (!accum) return false;
-
-    if (isPrefix)
+    /**
+     * Binds a patch to an object. All patches are accumulated even after initial binding.
+     * @param patch 
+     * @returns false if this patch has already been bound
+     */
+    Apply(patch: FlowerPatch): boolean
     {
-        accum.prefixes.push(patch);
-    }
-    else
-    {
-        accum.postfixes.push(patch);
+
+        /** Only apply patches once ever */
+        if (patch.applied)
+            return false;
+
+        /* eslint-disable-next-line @typescript-eslint/ban-types */
+        const orig = patch.obj[patch.methodName] as Function;
+        const Patcher = this;
+
+        const wrapper: PatchFn = function (...args)
+        {
+            Patcher.MyLogSource.writeDebug(`Running detour for ${patch.methodName}`);
+            // <-- this = obj
+
+            patch = Patcher.FindPatch(patch.obj, patch.methodName)!;
+
+            Patcher.MyLogSource.writeDebug(`Prefixes ${patch.prefixes.length}`);
+            //patch.prefixes.forEach(prefix => prefix.call(patch.obj, ...args));
+            //Allow ending the detour early
+            for (const prefix of patch.prefixes)
+            {
+                if (false === prefix.call(patch.obj, ...args))
+                {
+                    Patcher.MyLogSource.writeDebug("Ending detour");
+                    return;
+                }
+            }
+
+            let origRet;
+
+            try
+            {
+                origRet = orig.call(patch.obj, ...args);
+            }
+            catch (e)
+            {
+                Patcher.MyLogSource.write(`Error running orig: ${e}`)
+                return;
+            }
+
+            /**
+             * Todo: allow postfixes to modify the return data here
+             */
+
+            Patcher.MyLogSource.writeDebug(`Postfixes ${patch.postfixes.length}`);
+
+            for (const postfix of patch.postfixes)
+            {
+                try
+                {
+                    postfix.call(patch.obj, ...args)
+                }
+                catch (e: any)
+                {
+                    Patcher.MyLogSource.write(`Failed to run postfix: ${e.message}`);
+                }
+            }
+
+
+            return origRet;
+        }
+
+        patch.obj[patch.methodName] = wrapper.bind(patch.obj);
+        return true;
     }
 
-    Apply(accum);
-    return true;
+    /**
+     * Registers a new patch with flower
+     * @param obj any object that contains a method
+     * @param methodName the string name of the method to patch
+     * @param patch a function that runs when the method is called
+     * @param isPrefix if this should run before the method (afterward otherwise)
+     * @returns true on success
+     */
+    RegisterPatch(obj: Patchable, methodName: string, patch: PatchFn, isPrefix: boolean)
+    {
+
+        this.MyLogSource.writeDebug(`Running RegisterPatch for ${methodName}`);
+
+        const accum = this.FindPatch(obj, methodName);
+        if (!accum) return false;
+
+        if (isPrefix)
+        {
+            accum.prefixes.push(patch);
+        }
+        else
+        {
+            accum.postfixes.push(patch);
+        }
+
+        this.Apply(accum);
+        return true;
+    }
+
+    constructor(LogSource: LogSource)
+    {
+        this.MyLogSource = LogSource;
+    }
 }

--- a/flowerful.ts
+++ b/flowerful.ts
@@ -6,7 +6,7 @@ import { FlowerAPI, IFlowerPlugin, isModule, LogSource } from "@flowerloader/api
 import { flowerPatcher } from "./flowerful.patches";
 
 /* Set this to true to get ALL the spammy log messages */
-const debuglogging = true;
+const debuglogging = false;
 
 type LogCallback = (title: string, message: string) => void;
 
@@ -23,7 +23,7 @@ export class flowerCore<T>
     {
         /* eslint-disable-next-line @typescript-eslint/no-var-requires */
         const fs = require('fs');
-        const plugin_dir = "${plugin_root}/flower-plugins/";
+        const plugin_dir = `${plugin_root}/flower-plugins/`;
 
         const files = fs.readdirSync(plugin_dir, {})
         this.MyLogSource.writeDebug(`Loading ${files.length} plugins`);

--- a/flowerful.ts
+++ b/flowerful.ts
@@ -2,197 +2,123 @@
  * Flowerful runtime detour library for Creator of Another World
  */
 
-import { FlowerAPI, FlowerModule, IFlowerPlugin, isModule, LogSource } from "@flowerloader/api";
-import { RegisterPatch, ApplyAllPatches } from "./flowerful.patches";
-
-/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-declare const nw: any;
+import { FlowerAPI, IFlowerPlugin, isModule, LogSource } from "@flowerloader/api";
+import { ApplyAllPatches } from "./flowerful.patches";
 
 /* Set this to true to get ALL the spammy log messages */
 const debuglogging = true;
 
-/**
- * This is how long flower waits in ms before setting up at the start
- * This will need to be configurable on a per-game basis
- */
-const timeout = 100;
-
-//#region flower_ctor
-
-//To communicate with the logger window
-//Internal to flower only
-const flower = {
-    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-    logger: {} as { window: Window },
-};
-
-//This is what is sent to plugins when registering
-const flowerAPI: FlowerAPI =
+export class flowerCore<T>
 {
-    RegisterPatch: RegisterPatch,
-    GetGameMain: GetGameMain,
-};
+    //All the plugins live here
+    Plugins: { [key: string]: IFlowerPlugin } = {};
+    LogCallback: (title: string, message: string) => void;
+    API: FlowerAPI<T>;
 
-//All plugins live here
-const Plugins: { [key: string]: IFlowerPlugin } = {};
-
-//#endregion flower_ctor
-
-//#region flower-core
-
-function GetGameMain()
-{
-    //@ts-ignore
-    return tWgm;
-}
-
-async function LoadAllPlugins()
-{
-    /* eslint-disable-next-line @typescript-eslint/no-var-requires */
-    const fs = require('fs');
-    const plugin_dir = nw.global.__dirname + "/gamedata/game/js/game/flower-plugins/";
-
-    const files = fs.readdirSync(plugin_dir, {})
-    WriteDebug(`Loading ${files.length} plugins`);
-
-    for (const file of files)
+    LoadAllPlugins = async (plugin_root: string) =>
     {
-        WriteDebug(`Loading File: ${file}`);
-        await LoadPlugin(file);
+        /* eslint-disable-next-line @typescript-eslint/no-var-requires */
+        const fs = require('fs');
+        const plugin_dir = "${plugin_root}/flower-plugins/";
+
+        const files = fs.readdirSync(plugin_dir, {})
+        this.WriteDebug(`Loading ${files.length} plugins`);
+
+        for (const file of files)
+        {
+            this.WriteDebug(`Loading File: ${file}`);
+            await this.LoadPlugin(file);
+        }
+
+        this.WriteDebug(`Running awakes for plugins`);
+
+        for (const guid in this.Plugins)
+        {
+            try
+            {
+                this.Plugins[guid].Awake();
+            } catch (e: any)
+            {
+                this.WriteMessage(`Error loading ${guid}: ${e.message}`);
+                delete this.Plugins[guid];
+                //Strech goals: Delete patches from bad boys that fail on Awake()
+            }
+
+        }
+
+        //This should be completely redundant now
+        ApplyAllPatches();
     }
 
-    WriteDebug(`Running awakes for plugins`);
-
-    for (const guid in Plugins)
+    LoadPlugin = async (file: string) =>
     {
+        const filePath = `./flower-plugins/${file}`
+        this.WriteMessage(`Importing ${filePath}`);
+
         try
         {
-            Plugins[guid].Awake();
-        } catch (e: any)
-        {
-            WriteLog("Flower", `Error loading ${guid}: ${e.message}`);
-            delete Plugins[guid];
-            //Strech goals: Delete patches from bad boys that fail on Awake()
-        }
 
-    }
+            const maybePlugin = (await import(filePath));
 
-    //This should be completely redundant now
-    ApplyAllPatches();
-}
-
-async function LoadPlugin(file: string)
-{
-    const filePath = `./flower-plugins/${file}`
-    WriteLog("Flower", `Importing ${filePath}`);
-
-    try
-    {
-
-        const maybePlugin = (await import(filePath));
-
-        if (isModule(maybePlugin))
-        {
-
-            const {
-                META: meta, default: pluginConstructor
-            } = maybePlugin;
-
-            if (!Plugins[meta.GUID])
+            if (isModule(maybePlugin))
             {
-                //Squawk
-                WriteDebug(`Registering ${meta.GUID}`);
 
-                //Check plugin is enabled
-                if (!meta.ENABLED)
+                const {
+                    META: meta, default: pluginConstructor
+                } = maybePlugin;
+
+                if (!this.Plugins[meta.GUID])
                 {
-                    WriteDebug("Skipping, plugin is disabled");
-                    return;
+                    //Squawk
+                    this.WriteDebug(`Registering ${meta.GUID}`);
+
+                    //Check plugin is enabled
+                    if (!meta.ENABLED)
+                    {
+                        this.WriteDebug("Skipping, plugin is disabled");
+                        return;
+                    }
+
+                    //Where the magic happens
+                    const plugin = new pluginConstructor(this.API, new LogSource(meta.GUID, this.WriteMessage));
+
+                    this.Plugins[meta.GUID] = plugin;
+
                 }
-
-                //Where the magic happens
-                const plugin = new pluginConstructor(flowerAPI, new LogSource(meta.GUID, WriteLog));
-
-                Plugins[meta.GUID] = plugin;
-
+                else
+                {
+                    throw new Error("Duplicate plugin loaded");
+                }
             }
             else
-            {
-                throw new Error("Duplicate plugin loaded");
-            }
+                throw new Error("Not a valid plugin")
+
         }
-        else
-            throw new Error("Not a valid plugin")
-
-    }
-    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-    catch (e: any)
-    {
-        WriteLog("Flower", `Error loading: ${e.message}`);
-        return;
-    }
-
-}
-
-//#endregion flower-core
-
-//#region flower-logger
-
-export function WriteDebug(message: string)
-{
-    if (!debuglogging)
-        return;
-
-    WriteLog("Flower Debug", message);
-}
-
-export function WriteLog(title: string, message: string)
-{
-
-    const logBody = flower.logger.window.document.getElementById("log-body");
-    const el = flower.logger.window.document.createElement("div");
-    el.className = "log-entry"
-    el.innerHTML = `<div class="head">${title}</div>
-                        <div class="body">${message}</div>`;
-
-    logBody?.insertBefore(el, logBody.firstChild)
-
-}
-
-function SetupLogger()
-{
-    //Logger window
-    const url = "file:///" + nw.global.__dirname + "/gamedata/game/logger.html";
-    nw.Window.open(url, {
-        /*frame: debbug,*/
-        width: 600,
-        height: 800,
         /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-    }, function (win: any)
-    {
-        win.once('loaded', function ()
+        catch (e: any)
         {
-            onLoggerWindowLoaded(win);
-        });
-    });
-}
+            this.WriteMessage(`Error loading: ${e.message}`);
+            return;
+        }
 
-/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-function onLoggerWindowLoaded(win: any)
-{
-    flower.logger = win;
-    //win.window.document.body.innerHTML += "<h2>Executable Started</h2>";
+    }
 
-    //Start patchloading here
-    LoadAllPlugins();
-}
-
-//#endregion flower-logger
-
-window.onload = function ()
-{
-    window.setTimeout(() =>
+    WriteMessage = (message: string) =>
     {
-        SetupLogger();
-    }, timeout);
-};
+        this.LogCallback("Flower", message)
+    }
+
+    WriteDebug = (message: string) =>
+    {
+        if (!debuglogging)
+            return;
+
+        this.LogCallback("Flower Debug", message);
+    }
+
+    constructor(LogDest: (title: string, message: string) => void, API: FlowerAPI<T>)
+    {
+        this.LogCallback = LogDest;
+        this.API = API;
+    }
+}

--- a/flowerful.ts
+++ b/flowerful.ts
@@ -15,7 +15,7 @@ const debuglogging = true;
  * This is how long flower waits in ms before setting up at the start
  * This will need to be configurable on a per-game basis
  */
-const timeout = 75;
+const timeout = 100;
 
 //#region flower_ctor
 

--- a/flowerful.ts
+++ b/flowerful.ts
@@ -9,7 +9,13 @@ import { RegisterPatch, ApplyAllPatches } from "./flowerful.patches";
 declare const nw: any;
 
 /* Set this to true to get ALL the spammy log messages */
-const debuglogging = false;
+const debuglogging = true;
+
+/**
+ * This is how long flower waits in ms before setting up at the start
+ * This will need to be configurable on a per-game basis
+ */
+const timeout = 75;
 
 //#region flower_ctor
 
@@ -163,7 +169,10 @@ function SetupLogger()
         /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
     }, function (win: any)
     {
-        win.once('loaded', function () { onLoggerWindowLoaded(win) });
+        win.once('loaded', function ()
+        {
+            onLoggerWindowLoaded(win);
+        });
     });
 }
 
@@ -181,5 +190,8 @@ function onLoggerWindowLoaded(win: any)
 
 window.onload = function ()
 {
-    SetupLogger();
+    window.setTimeout(() =>
+    {
+        SetupLogger();
+    }, timeout);
 };

--- a/flowerful.ts
+++ b/flowerful.ts
@@ -77,6 +77,7 @@ async function LoadAllPlugins()
 
     }
 
+    //This should be completely redundant now
     ApplyAllPatches();
 }
 

--- a/gameSupport/games.coaw.ts
+++ b/gameSupport/games.coaw.ts
@@ -1,0 +1,79 @@
+// --- @flowerloader/types ---
+
+import { FlowerAPI } from "@flowerloader/api";
+import { RegisterPatch } from "../flowerful.patches";
+import { GameDataCOAW, tGameMain } from "@flowerloader/coawtypes";
+import { flowerCore } from "../flowerful";
+
+/**
+ * This is how long flower waits in ms before setting up at the start
+ * This will need to be configurable on a per-game basis
+ */
+const timeout = 100;
+
+/**
+ * This is where we store the logger window for coaw
+ */
+let logger: any = {} as { window: Window };
+
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+declare const nw: any;
+declare const tWgm: tGameMain;
+
+const flowerAPI: FlowerAPI<GameDataCOAW> = {
+    GetGameMain: () => { return { tGameMain: tWgm } },
+    RegisterPatch: RegisterPatch,
+}
+
+let core: flowerCore<GameDataCOAW> = new flowerCore(WriteLog, flowerAPI)
+
+export function WriteLog(title: string, message: string)
+{
+
+    const logBody = logger.window.document.getElementById("log-body");
+    const el = logger.window.document.createElement("div");
+    el.className = "log-entry"
+    el.innerHTML = `<div class="head">${title}</div>
+                        <div class="body">${message}</div>`;
+
+    logBody?.insertBefore(el, logBody.firstChild)
+
+}
+
+function SetupLogger()
+{
+    //Logger window
+    const url = "file:///" + nw.global.__dirname + "/gamedata/game/logger.html";
+    nw.Window.open(url, {
+        /*frame: debbug,*/
+        width: 600,
+        height: 800,
+        /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    }, function (win: any)
+    {
+        win.once('loaded', function ()
+        {
+            onLoggerWindowLoaded(win);
+        });
+    });
+}
+
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+function onLoggerWindowLoaded(win: any)
+{
+    logger = win;
+    //win.window.document.body.innerHTML += "<h2>Executable Started</h2>";
+
+    //Start patchloading here
+    core.LoadAllPlugins(nw.global.__dirname + "/gamedata/game/js/game");
+}
+
+window.onload = function ()
+{
+    window.setTimeout(() =>
+    {
+        SetupLogger();
+    }, timeout);
+};
+
+export default function GetFlowerAPI() { return flowerAPI }

--- a/gameSupport/games.coaw.ts
+++ b/gameSupport/games.coaw.ts
@@ -44,7 +44,7 @@ function WriteLog(title: string, message: string)
 function WriteDebug(title: string, message: string)
 {
     if (core.Debug)
-        WriteLog("DEBUG ${title}", message);
+        WriteLog(`DEBUG ${title}`, message);
 }
 
 

--- a/gameSupport/games.coaw.ts
+++ b/gameSupport/games.coaw.ts
@@ -1,7 +1,6 @@
 // --- @flowerloader/types ---
 
-import { FlowerAPI } from "@flowerloader/api";
-import { RegisterPatch } from "../flowerful.patches";
+import { FlowerAPI, LogSource } from "@flowerloader/api";
 import { GameDataCOAW, tGameMain } from "@flowerloader/coawtypes";
 import { flowerCore } from "../flowerful";
 
@@ -22,12 +21,15 @@ declare const tWgm: tGameMain;
 
 const flowerAPI: FlowerAPI<GameDataCOAW> = {
     GetGameMain: () => { return { tGameMain: tWgm } },
-    RegisterPatch: RegisterPatch,
+    RegisterPatch(obj, methodName, patch, isPrefix)
+    {
+        throw new Error("Not implemented");
+    },
 }
 
-let core: flowerCore<GameDataCOAW> = new flowerCore(WriteLog, flowerAPI)
+let core: flowerCore<GameDataCOAW> = new flowerCore(new LogSource("Flower", WriteLog, WriteDebug), flowerAPI)
 
-export function WriteLog(title: string, message: string)
+function WriteLog(title: string, message: string)
 {
 
     const logBody = logger.window.document.getElementById("log-body");
@@ -37,8 +39,15 @@ export function WriteLog(title: string, message: string)
                         <div class="body">${message}</div>`;
 
     logBody?.insertBefore(el, logBody.firstChild)
-
 }
+
+function WriteDebug(title: string, message: string)
+{
+    if (core.Debug)
+        WriteLog("DEBUG ${title}", message);
+}
+
+
 
 function SetupLogger()
 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "CC BY-NC 4.0",
       "dependencies": {
-        "@flowerloader/api": "file:../../api.next",
-        "@flowerloader/coawtypes": "file:../../CoaWTypes"
+        "@flowerloader/api": "^1.2.0",
+        "@flowerloader/coawtypes": "^1.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.2.0",
@@ -24,10 +24,13 @@
     "../../api.next": {
       "name": "@flowerloader/api",
       "version": "1.1.0",
+      "extraneous": true,
       "license": "CC BY-NC-SA 4.0"
     },
     "../../CoaWTypes": {
+      "name": "@flowerloader/coawtypes",
       "version": "1.0.0",
+      "extraneous": true,
       "license": "CC-BY-NC-SA-4.0"
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -102,12 +105,14 @@
       }
     },
     "node_modules/@flowerloader/api": {
-      "resolved": "../../api.next",
-      "link": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@flowerloader/api/-/api-1.2.0.tgz",
+      "integrity": "sha512-dHCrLy/0gIC5OePaP8f2UzVQcnKlndbUTVi+1xDnf+txq43c8yqzsFgIDr909/9QnsMYecXxzkPeMbOMRvNR0w=="
     },
     "node_modules/@flowerloader/coawtypes": {
-      "resolved": "../../CoaWTypes",
-      "link": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@flowerloader/coawtypes/-/coawtypes-1.0.0.tgz",
+      "integrity": "sha512-da5FzKmQjkqYFMvBYHVLHV2eDX91ZiIUkC5S8a55nq8tuNvqan/a42c2O+pCDw7n0Jr32DA8LG0N8s2N+un7MQ=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -1698,10 +1703,14 @@
       "dev": true
     },
     "@flowerloader/api": {
-      "version": "file:../../api.next"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@flowerloader/api/-/api-1.2.0.tgz",
+      "integrity": "sha512-dHCrLy/0gIC5OePaP8f2UzVQcnKlndbUTVi+1xDnf+txq43c8yqzsFgIDr909/9QnsMYecXxzkPeMbOMRvNR0w=="
     },
     "@flowerloader/coawtypes": {
-      "version": "file:../../CoaWTypes"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@flowerloader/coawtypes/-/coawtypes-1.0.0.tgz",
+      "integrity": "sha512-da5FzKmQjkqYFMvBYHVLHV2eDX91ZiIUkC5S8a55nq8tuNvqan/a42c2O+pCDw7n0Jr32DA8LG0N8s2N+un7MQ=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "CC BY-NC 4.0",
       "dependencies": {
-        "@flowerloader/api": "file:../../api.next"
+        "@flowerloader/api": "file:../../api.next",
+        "@flowerloader/coawtypes": "file:../../CoaWTypes"
       },
       "devDependencies": {
         "@eslint/js": "^9.2.0",
@@ -21,8 +22,13 @@
       }
     },
     "../../api.next": {
+      "name": "@flowerloader/api",
       "version": "1.1.0",
       "license": "CC BY-NC-SA 4.0"
+    },
+    "../../CoaWTypes": {
+      "version": "1.0.0",
+      "license": "CC-BY-NC-SA-4.0"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -97,6 +103,10 @@
     },
     "node_modules/@flowerloader/api": {
       "resolved": "../../api.next",
+      "link": true
+    },
+    "node_modules/@flowerloader/coawtypes": {
+      "resolved": "../../CoaWTypes",
       "link": true
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1689,6 +1699,9 @@
     },
     "@flowerloader/api": {
       "version": "file:../../api.next"
+    },
+    "@flowerloader/coawtypes": {
+      "version": "file:../../CoaWTypes"
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "CC BY-NC 4.0",
       "dependencies": {
-        "@flowerloader/api": "^1.0.0"
+        "@flowerloader/api": "file:../../api.next"
       },
       "devDependencies": {
         "@eslint/js": "^9.2.0",
@@ -19,6 +19,10 @@
         "typescript": "^5.4.5",
         "typescript-eslint": "^7.9.0"
       }
+    },
+    "../../api.next": {
+      "version": "1.1.0",
+      "license": "CC BY-NC-SA 4.0"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -92,9 +96,8 @@
       }
     },
     "node_modules/@flowerloader/api": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@flowerloader/api/-/api-1.1.0.tgz",
-      "integrity": "sha512-7sxqRwHvFIq02gGKMVjSB1T5cRIyAhp8bEq6qp3i1oNTjsnq8C4v0ERDqXdPXOY7qyboXxv1yLGgRRyLaAmg+A=="
+      "resolved": "../../api.next",
+      "link": true
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -1685,9 +1688,7 @@
       "dev": true
     },
     "@flowerloader/api": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@flowerloader/api/-/api-1.1.0.tgz",
-      "integrity": "sha512-7sxqRwHvFIq02gGKMVjSB1T5cRIyAhp8bEq6qp3i1oNTjsnq8C4v0ERDqXdPXOY7qyboXxv1yLGgRRyLaAmg+A=="
+      "version": "file:../../api.next"
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.14",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typescript-eslint": "^7.9.0"
   },
   "dependencies": {
-    "@flowerloader/api": "file:../../api.next",
-    "@flowerloader/coawtypes": "file:../../CoaWTypes"
+    "@flowerloader/api": "^1.2.0",
+    "@flowerloader/coawtypes": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "typescript-eslint": "^7.9.0"
   },
   "dependencies": {
-    "@flowerloader/api": "file:../../api.next"
+    "@flowerloader/api": "file:../../api.next",
+    "@flowerloader/coawtypes": "file:../../CoaWTypes"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "typescript-eslint": "^7.9.0"
   },
   "dependencies": {
-    "@flowerloader/api": "^1.0.0"
+    "@flowerloader/api": "file:../../api.next"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,10 @@
-<h1>Flower Loader</h1>
+<h1>Flower Loader CLI</h1>
 
 ![Static Badge](https://img.shields.io/badge/Language-Typescript_ESM-blue?style=for-the-badge&logo=typescript)
 
 ![License](https://img.shields.io/badge/License-CC_BY--NC--SA_4.0-yellowgreen?style=for-the-badge&logo=creativecommons)
 
-**Flower Loader** is a Plugin loader and detour manager for Node.js applications. With Flower Loader, you can easily manage and develop Plugins. This repository contains the core plugin loader. It is built with ESBuild and is source-available under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
+**Flower Loader** is a Plugin Manager for `Creator of Another World`. With Flower Loader, you can easily manage and develop Plugins. This repository contains the core plugin loader. It is built with ESBuild and is source-available under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
 
 <h2>Get Involved</h2>
 

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,10 @@
-<h1>Flower Loader CLI</h1>
+<h1>Flower Loader</h1>
 
 ![Static Badge](https://img.shields.io/badge/Language-Typescript_ESM-blue?style=for-the-badge&logo=typescript)
 
 ![License](https://img.shields.io/badge/License-CC_BY--NC--SA_4.0-yellowgreen?style=for-the-badge&logo=creativecommons)
 
-**Flower Loader** is a Plugin Manager for `Creator of Another World`. With Flower Loader, you can easily manage and develop Plugins. This repository contains the core plugin loader. It is built with ESBuild and is source-available under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
+**Flower Loader** is a Plugin loader and detour manager for Node.js applications. With Flower Loader, you can easily manage and develop Plugins. This repository contains the core plugin loader. It is built with ESBuild and is source-available under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
 
 <h2>Get Involved</h2>
 


### PR DESCRIPTION
Finally, all our work pays off. This update completely re-writes the deploy strategy of Flowerloader from being the main entrypoint into the program to being split across 3 segments.

## The Game Specific Definitions
At the topmost layer: The game definitions define what method is used for logging and hooking into the supported game. The definitions then create layer 2 and supply it with the callbacks needed for logging. This allows games to define what surface is used for logging (if any) and if any other conditions (E.G. a timeout) should occur before hooking is completed. @AlbinoGeek put a lot of work into outlining the way the new system should work, since Typescript definitions still sorta confuse me a little, hehe. Thanks.

## The Core
Once the game definitions have had their time to run, they hand off execution to the flowerCore. FlowerCore locates and loads every plugin, passes them the requisite LogSources and organizes the loaded plugin list by reading plugin metadata. It also handles exceptions and issues that arise during plugin loading. It has no concept of what game it is being run in and operates fully independently of the game-specific definitions files. Once its job is complete, all plugins are loaded and ready to operate.

## The Patcher
FlowerPatcher is not directly called by any of the other layers, it exists horizontally to flowerCore and simply waits until triggered by plugins requesting a patch be created and applied to an object or method. In many ways, flowerPatcher is the beating heart of flowerLoader as, without it, all plugins would only run static code and responding to game events would be much harder. The majority of plugins will register many patches to achieve their goal.