### PR TITLE
Coaw support update

### DIFF
--- a/gameSupport/games.coaw.ts
+++ b/gameSupport/games.coaw.ts
@@ -7,6 +7,8 @@ import { flowerCore } from "../flowerful";
 /**
  * Returns the platform specific game location
  */
+// This is only used in plugins and will always throw an unused error if not ignored
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function GetGameRoot(): string
 {
     //chrome-extension://eobfdhbhahidclhbabnladfbafcbfdmn/gamedata/game/flower/flower-plugins/
@@ -17,6 +19,7 @@ function GetGameRoot(): string
     base = base.replace("index.html", "")
     console.log(base)
 
+    //@ts-expect-error Global does exist, the defs are wrong but we don't control the defs
     base = base.replace("chrome-extension://eobfdhbhahidclhbabnladfbafcbfdmn", nw.global.__dirname);
     console.log(base)
 
@@ -32,6 +35,8 @@ const timeout = 500;
 /**
  * This is where we store the logger window for coaw
  */
+// this is jank but its how we define the window to get TS support
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 let logger: any = {} as { window: Window };
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
@@ -39,13 +44,16 @@ declare const tWgm: tGameMain;
 
 const flowerAPI: FlowerAPI<GameDataCOAW> = {
     GetGameMain: () => { return { tGameMain: tWgm } },
+
+    // This is only used in plugins and will always throw an unused error if not ignored
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     RegisterPatch(obj, methodName, patch, isPrefix)
     {
         throw new Error("Not implemented");
     },
 }
 
-let core: flowerCore<GameDataCOAW> = new flowerCore(new LogSource("Flower", WriteLog, WriteDebug), flowerAPI)
+const core: flowerCore<GameDataCOAW> = new flowerCore(new LogSource("Flower", WriteLog, WriteDebug), flowerAPI)
 
 function WriteLog(title: string, message: string)
 {

--- a/gameSupport/games.coaw.ts
+++ b/gameSupport/games.coaw.ts
@@ -126,8 +126,6 @@ function trySetup()
     }
 }
 
-console.log("WAAH");
-console.error("ERROR WAAH");
 trySetup();
 
 //pretty sure we don't need this

--- a/gameSupport/games.coaw.ts
+++ b/gameSupport/games.coaw.ts
@@ -30,7 +30,8 @@ function GetGameRoot(): string
  * This is how long flower waits in ms before setting up at the start
  * This will need to be configurable on a per-game basis
  */
-const timeout = 500;
+const timeout = 10;
+let loops = 0;
 
 /**
  * This is where we store the logger window for coaw
@@ -94,17 +95,40 @@ function onLoggerWindowLoaded(win: any)
     logger = win;
     //win.window.document.body.innerHTML += "<h2>Executable Started</h2>";
 
+    //Goofy debug
+    WriteLog("Loaded", `Loading took ${loops * timeout}ms to finish`);
+
     //Start patchloading here
     core.LoadAllPlugins("./flower");
 }
 
-window.onload = function ()
+function trySetup()
 {
-    window.setTimeout(() =>
+
+    loops++;
+    //console.log("Checking for setup");
+
+
+    //cancel setup
+    if (tWgm == null || tWgm.tGameCharactor == null)
     {
+        //console.log("Running setup again later");
+        //setup must retry later in the game
+        window.setTimeout(() =>
+        {
+            trySetup();
+        }, timeout);
+    }
+    else
+    {
+        //console.log("Setting up now")
         SetupLogger();
-    }, timeout);
-};
+    }
+}
+
+console.log("WAAH");
+console.error("ERROR WAAH");
+trySetup();
 
 //pretty sure we don't need this
 //export default function GetFlowerAPI() { return flowerAPI }


### PR DESCRIPTION
Rewrites the core loading path to include a delay until tWgm.tGameCharactor exists, this should ensure that tGameMain.init2 has finished and that it is safe to run the rest of flower's startup procedure.